### PR TITLE
feat: ignore-devcontainer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,6 @@ packages/solid/src/jsx.d.ts
 packages/solid/web/server/server.d.ts
 packages/solid/web/src/client.d.ts
 
-# vscode devcontainers
+# vscode devcontainers see issues #419 and #421 for context
 /.devcontainer.json
 /devcontainer

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,7 @@ types/
 packages/solid/src/jsx.d.ts
 packages/solid/web/server/server.d.ts
 packages/solid/web/src/client.d.ts
+
+# vscode devcontainers
+/.devcontainer.json
+/devcontainer


### PR DESCRIPTION
As an alternative to #419, this PR adds `/.devcontainer.json` and `/devcontainer` to the `.gitignore` list. This seems appropriate if a devcontainer isn't going to be added to the repo at this time. In the future this can always be undone, but in the meantime it will make it easier for contributors to use `devcontainers` on their own.